### PR TITLE
Add link to delve's talk slides

### DIFF
--- a/gophercon_iceland/README.md
+++ b/gophercon_iceland/README.md
@@ -126,8 +126,8 @@ http://peter.bourgon.org/go-for-industrial-programming/
 #### Internal Architecture of Delve, a Debugger for Go
 **Speaker**<br/>
 [Alessandro Arzilli](https://github.com/aarzilli "Alessandro Arzilli")<br/>
-**Resources**
-
+**Resources**<br/>
+https://speakerdeck.com/aarzilli/internal-architecture-of-delve
 
 ------------
 


### PR DESCRIPTION
I've added a link to the slides of my talk on delve's internals.